### PR TITLE
pipelines can provide env. variables to the build environment

### DIFF
--- a/configure-pipeline
+++ b/configure-pipeline
@@ -26,8 +26,9 @@ output_path="-"
 uarch="-"
 system="-"
 uenv="-"
+buildenv="-"
 
-while getopts c:r:o:s:u:a: flag
+while getopts c:r:o:s:u:a:b: flag
 do
     case "${flag}" in
         c) config_path=${OPTARG};;
@@ -36,6 +37,7 @@ do
         a) uarch=${OPTARG};;
         s) system=${OPTARG};;
         u) uenv=${OPTARG};;
+        b) buildenv=${OPTARG};;
     esac
 done
 
@@ -62,6 +64,17 @@ log "config_path  = $config_path"
 log "pipeline_path= $pipeline_path"
 log "recipe_path  = $recipe_path"
 log "output_path  = $output_path"
+log "buildenv     = $buildenv"
+
+# buildenv is an optional argument that should be the relative path to a json
+# file that describes environment variables to set during the build phase.
+if [ "-" != "${buildenv}" ]
+then
+    buildenvabs="$(realpath ${buildenv})"
+    [[ ! -f "${buildenvabs}"]] && usage "invalide -b parameter: the file ${buildenvabs} does not exist"
+    log "using build environment file ${buildenvabs}"
+    buildenvarg="--buildenv=${buildenvabs}"
+fi
 
 #
 # create temporary working path for python
@@ -88,7 +101,7 @@ pip install --upgrade --quiet pip
 pip install --quiet -r $pipeline_path/requirements.txt
 log "installed python dependencies"
 
-${pipeline_path}/ci.py --recipes="$recipe_path" --config="$config_path" --uarch="$uarch" --uenv="$uenv" --system="$system" --output="$output_path"
+${pipeline_path}/ci.py --recipes="$recipe_path" --config="$config_path" --uarch="$uarch" --uenv="$uenv" --system="$system" --output="$output_path" ${buildenvarg}
 [[ $? -eq 0  ]] || err "unable to configure"
 
 log "configuration complete"

--- a/pipeline/ci.py
+++ b/pipeline/ci.py
@@ -59,6 +59,10 @@ def readenv(config, args):
 
     recipe = config.recipe(uenv, version, uarch)
 
+    build_env = ""
+    if args.buildenv != "":
+        build_env = f"-e {args.buildenv}"
+
     if recipe is None:
         raise EnvError(f"the recipe {uenv}/{version} is not available for the {uarch} target")
 
@@ -69,6 +73,7 @@ def readenv(config, args):
         "version": version,
         "recipe": recipe,
         "pipeline_path": root_path,
+        "buildenv": build_env
     }
 
 def make_argparser():
@@ -84,6 +89,7 @@ def make_argparser():
     # that is looked up in the recipes path via the cluster config
     parser.add_argument("-r", "--recipes", required=True, type=str)
     parser.add_argument("-u", "--uenv", required=True, type=str)
+    parser.add_argument("-b", "--buildenv", default="", type=str)
 
     return parser
 

--- a/pipeline/templates/pipeline.yml
+++ b/pipeline/templates/pipeline.yml
@@ -11,7 +11,7 @@ stages:
   variables:
     SLURM_TIMELIMIT: 180
   script:
-  - ./uenv-pipeline/stage-build -n $STACK_NAME -s $STACK_SYSTEM -r $STACK_RECIPE -b /dev/shm/jenkssl $SPACK_DEVELOP -m $STACK_MOUNT -u $STACK_UARCH $NO_BWRAP
+  - ./uenv-pipeline/stage-build -n $STACK_NAME -s $STACK_SYSTEM -r $STACK_RECIPE -b /dev/shm/jenkssl $SPACK_DEVELOP -m $STACK_MOUNT -u $STACK_UARCH $NO_BWRAP $BUILD_ENV
   after_script:
   - rm -Rf /dev/shm/jenkssl
 
@@ -45,6 +45,7 @@ build-{{job.uenv}}/{{job.version}}-{{job.system}}/{{job.uarch}}:
     STACK_RECIPE:     "{{job.recipe_path}}"
     STACK_UARCH:      "{{job.uarch}}"
     SLURM_PARTITION:  "{{job.partition}}"
+    BUILD_ENV:        "{{job.buildenv}}"
     {% for name, value in job.runner.variables.items() %}
     {{ name }}: "{{ value }}"
     {% endfor %}

--- a/stage-build
+++ b/stage-build
@@ -32,7 +32,7 @@ get_build_id () {
 }
 
 usage () {
-    echo "usage: stage-build -n name -r recipe-path -s system -b build-root -u uarch -m mount [-d] [-w] [-t]"
+    echo "usage: stage-build -n name -r recipe-path -s system -b build-root -u uarch -m mount -e envfile [-d] [-w] [-t]"
     echo ""
     echo "where:"
     echo "  name:        the name of the stack"
@@ -41,6 +41,7 @@ usage () {
     echo '  build-root:  the root path in which to perform the build, e.g. /dev/shm/$USER'
     echo "  uarch:       the target micro-architecture"
     echo "  mount:       the mount point of the image"
+    echo "  envfile:     an optional file containing environment variables to set during the build"
     echo ""
     echo "-d: enable spack develop mode"
     echo "-w: enable no-bwrap mode"
@@ -55,6 +56,7 @@ recipe_path="-"
 build_root="-"
 uarch="-"
 mount="-"
+envfile=""
 spack_develop=""
 no_bwrap=""
 # if this is set to "yes", assume we are doing a manual test run and don
@@ -72,6 +74,7 @@ do
         b) build_root="${OPTARG}";;
         u) uarch=${OPTARG};;
         m) mount=${OPTARG};;
+        e) envfile=${OPTARG}
         d) spack_develop="--develop";;
         w) no_bwrap="--no-bwrap";;
         t) test_run="yes";;
@@ -101,15 +104,24 @@ log "build-path     ${build_path}"
 log "ci-path        ${ci_path}"
 log "pipeline-path  ${pipeline_path}"
 log "mount          ${mount}"
+[[ ! -z ${envfile} ]] && log "envfile        ${envfile}"
 [[ ! -z ${spack_develop} ]] && log "develop"
 [[ ! -z ${no_bwrap} ]] && log "no bwrap"
 [[ "${test_run}" == "yes" ]] && log "running in test mode"
+
 
 # Check if the recipe path exists
 [[ -d "${recipe_path}" ]] || err "recipe path '$recipe_path' does not exist"
 
 # add pipeline directory to PATH
 export PATH="${pipeline_path}:$PATH"
+
+# generate additional arguments for the build phase
+envargs='PATH=/usr/bin:/bin:${PWD}/spack/bin  HOME=$HOME https_proxy=$https_proxy http_proxy=$http_proxy no_proxy="$no_proxy" CSCS_REGISTRY_USERNAME=$jfrog_u CSCS_REGISTRY_PASSWORD=$jfrog_p'
+if [ ! -z ${envfile} ]; then
+    extra_envargs=$(jq -r 'to_entries | map("\(.key)=\(.value)") | join(" ")' ${envfile})
+    envargs="$envargs $extra_envargs"
+fi
 
 ##
 # Set up build cache flags if a build cache is available
@@ -177,8 +189,8 @@ log "building image in ${build_path}"
 
 echo "env --ignore-environment PATH=/usr/bin:/bin:${PWD}/spack/bin make store.squashfs -j64"
 # Propagate username and password defined in ${pipeline_path}/util/setup-oras (to be used in pre-install script)
-env --ignore-environment PATH=/usr/bin:/bin:${PWD}/spack/bin  HOME=$HOME https_proxy=$https_proxy http_proxy=$http_proxy no_proxy="$no_proxy" CSCS_REGISTRY_USERNAME=$jfrog_u CSCS_REGISTRY_PASSWORD=$jfrog_p make store.squashfs -kj64
-[[ $? -eq 0  ]] || env --ignore-environment PATH=/usr/bin:/bin:${PWD}/spack/bin  HOME=$HOME https_proxy=$https_proxy http_proxy=$http_proxy no_proxy="$no_proxy" CSCS_REGISTRY_USERNAME=$jfrog_u CSCS_REGISTRY_PASSWORD=$jfrog_p make store.squashfs -kj8
+env --ignore-environment $envargs make store.squashfs -kj64
+[[ $? -eq 0  ]] || env --ignore-environment $envargs make store.squashfs -kj8
 
 if [ "$test_run" == "yes" ]; then
     exit 0;
@@ -187,7 +199,7 @@ fi
 if [ ! $? -eq 0 ]; then
     log "TODO: save WIP of build an store it for later inspection"
     log "pushing to build cache"
-    env --ignore-environment PATH=/usr/bin:/bin:${PWD}/spack/bin  HOME=$HOME https_proxy=$https_proxy http_proxy=$http_proxy no_proxy="$no_proxy" CSCS_REGISTRY_USERNAME=$jfrog_u CSCS_REGISTRY_PASSWORD=$jfrog_p make cache-force -j32
+    env --ignore-environment $envargs make cache-force -j32
     cp -r "${build_path}/tmp/jenkssl/spack-stage/" $CI_PROJECT_DIR
     err "error building image"
 fi


### PR DESCRIPTION
add support for pipelines to provide environment variables to forward to the build environment.

The pipeline would provide an JSON file, eg `buildenv.json`:

```json
{
  "GIT_CONFIG_COUNT": "1",
   "GIT_CONFIG_KEY_0": "url.[https://oauth2:${GITLAB_DKRZ_TOKEN}@gitlab.dkrz.de/.insteadOf](https://oauth2:$%7BGITLAB_DKRZ_TOKEN%7D@gitlab.dkrz.de/.insteadOf)",
   "GIT_CONFIG_VALUE_0": "[git@gitlab.dkrz.de](mailto:git@gitlab.dkrz.de):"
}
```

Then, when the pipeline calls `configure_pipeline` to generate the `pipeline.yaml` file, pass this as an argument:

`./uenv-pipeline/configure_pipeline -b ./buildenv.json ... `