### PR TITLE
fix subdirectory path in tmpdir

### DIFF
--- a/stage-build
+++ b/stage-build
@@ -183,7 +183,7 @@ env --ignore-environment PATH=/usr/bin:/bin:${PWD}/spack/bin  HOME=$HOME https_p
 if [ ! $? -eq 0 ]; then
     log "JOB Failed: pushing to build cache before exit"
     env --ignore-environment PATH=/usr/bin:/bin:${PWD}/spack/bin  HOME=$HOME https_proxy=$https_proxy http_proxy=$http_proxy no_proxy="$no_proxy" CSCS_REGISTRY_USERNAME=$jfrog_u CSCS_REGISTRY_PASSWORD=$jfrog_p make cache-force -j32
-    cp -r "${build_path}/tmp/uenv-build/spack-stage/" $CI_PROJECT_DIR
+    cp -r "${build_path}/tmp/$(id -un)/spack-stage/" $CI_PROJECT_DIR
     err "error building image"
 fi
 


### PR DESCRIPTION
The subdirectories name where `spack-stage` is inside is the username and not `uenv-build`.