### PR TITLE
remove --develop flag

### DIFF
--- a/pipeline/configuration.py
+++ b/pipeline/configuration.py
@@ -30,17 +30,12 @@ class Version:
         self._uenv_name = uenv_name
         self._recipes = desc["recipes"]
         self._deploy = desc["deploy"]
-        self._use_spack_develop = desc["develop"]
         self._mount = desc["mount"]
         self._recipe_path = recipe_path
 
     @property
     def name(self):
         return self._name
-
-    @property
-    def spack_develop(self):
-        return self._use_spack_develop
 
     @property
     def mount(self):
@@ -196,10 +191,7 @@ class Config:
         cluster = self.clusters[env["system"]]
         target = next(tgt for tgt in cluster["targets"] if tgt["uarch"]==env["uarch"])
 
-        develop = ""
         version = self.uenv(env["uenv"]).version(env["version"])
-        if version.spack_develop:
-            develop = "-d"
 
         no_bwrap = ""
         if cluster["no_bwrap"]:
@@ -239,7 +231,6 @@ class Config:
             "uarch": env["uarch"],
             "recipe_path": env["recipe"],
             "pipeline_path": env["pipeline_path"],
-            "spack_develop": develop,
             "no_bwrap": no_bwrap,
             "mount": version.mount,
             "system": env["system"],

--- a/pipeline/schema/config.json
+++ b/pipeline/schema/config.json
@@ -100,7 +100,6 @@
                                     },
                                     "default": {}
                                 },
-                                "develop": {"type": "boolean", "default": false},
                                 "mount":   {"type": "string", "default": "/user-environment"}
                             }
                         }

--- a/pipeline/templates/pipeline.yml
+++ b/pipeline/templates/pipeline.yml
@@ -11,7 +11,7 @@ stages:
   variables:
     SLURM_TIMELIMIT: 180
   script:
-  - ./uenv-pipeline/stage-build -n $STACK_NAME -s $STACK_SYSTEM -r $STACK_RECIPE -b /dev/shm/uenv-build $SPACK_DEVELOP -m $STACK_MOUNT -u $STACK_UARCH $NO_BWRAP
+  - ./uenv-pipeline/stage-build -n $STACK_NAME -s $STACK_SYSTEM -r $STACK_RECIPE -b /dev/shm/uenv-build -m $STACK_MOUNT -u $STACK_UARCH $NO_BWRAP
   after_script:
   - rm -Rf /dev/shm/uenv-build
 
@@ -37,7 +37,6 @@ build-{{job.uenv}}/{{job.version}}-{{job.system}}/{{job.uarch}}:
 {% endif %}
   variables:
     STACK_MOUNT:      "{{job.mount}}"
-    SPACK_DEVELOP:    "{{job.spack_develop}}"
     NO_BWRAP:         "{{job.no_bwrap}}"
     STACK_NAME:       "{{job.uenv}}/{{job.version}}"
     STACK_SYSTEM:     "{{job.system}}"
@@ -82,9 +81,8 @@ test-{{job.uenv}}/{{job.version}}-{{job.system}}/{{job.uarch}}:
 #@@cmd@@STACK_NAME="{{job.uenv}}/{{job.version}}"
 #@@cmd@@STACK_SYSTEM="{{job.system}}"
 #@@cmd@@STACK_RECIPE="{{job.recipe_path}}"
-#@@cmd@@SPACK_DEVELOP="{{job.spack_develop}}"
 #@@cmd@@STACK_MOUNT="{{job.mount}}"
 #@@cmd@@STACK_UARCH="{{job.uarch}}"
 #@@cmd@@NO_BWRAP="{{job.no_bwrap}}"
-#@@cmd@@./uenv-pipeline/stage-build -n $STACK_NAME -s $STACK_SYSTEM -r $STACK_RECIPE -b /dev/shm/uenv-build $SPACK_DEVELOP -m $STACK_MOUNT -u $STACK_UARCH $NO_BWRAP ${TESTRUN}
+#@@cmd@@./uenv-pipeline/stage-build -n $STACK_NAME -s $STACK_SYSTEM -r $STACK_RECIPE -b /dev/shm/uenv-build -m $STACK_MOUNT -u $STACK_UARCH $NO_BWRAP ${TESTRUN}
 {% endfor %}

--- a/stage-build
+++ b/stage-build
@@ -42,7 +42,6 @@ usage () {
     echo "  uarch:       the target micro-architecture"
     echo "  mount:       the mount point of the image"
     echo ""
-    echo "-d: enable spack develop mode"
     echo "-w: enable no-bwrap mode"
     echo "-t: disable pushing artifacts to registry"
     [[ "" == "$1" ]] && exit 0
@@ -55,7 +54,6 @@ recipe_path="-"
 build_root="-"
 uarch="-"
 mount="-"
-spack_develop=""
 no_bwrap=""
 # if this is set to "yes", assume we are doing a manual test run and do
 # not push to jfrog
@@ -74,7 +72,6 @@ do
         b) build_root="${OPTARG}";;
         u) uarch=${OPTARG};;
         m) mount=${OPTARG};;
-        d) spack_develop="--develop";;
         w) no_bwrap="--no-bwrap";;
         t) no_push="yes";;
     esac
@@ -103,7 +100,6 @@ log "build-path     ${build_path}"
 log "ci-path        ${ci_path}"
 log "pipeline-path  ${pipeline_path}"
 log "mount          ${mount}"
-[[ ! -z ${spack_develop} ]] && log "develop"
 [[ ! -z ${no_bwrap} ]] && log "no bwrap"
 [[ "${no_push}" == "yes" ]] && log "disabled push to registry"
 
@@ -180,8 +176,8 @@ source ${pipeline_path}/util/setup-stackinator
 # call stackinator
 log "configuring stack"
 
-echo "stack-config -r ${recipe_path} -b ${build_path} -s $cluster_path/${system} -m ${mount} $cache_flags ${spack_develop} ${no_bwrap}"
-stack-config -r "${recipe_path}" -b "${build_path}" -s "$cluster_path/${system}"  -m "${mount}" $cache_flags ${spack_develop} ${no_bwrap}
+echo "stack-config -r ${recipe_path} -b ${build_path} -s $cluster_path/${system} -m ${mount} $cache_flags ${no_bwrap}"
+stack-config -r "${recipe_path}" -b "${build_path}" -s "$cluster_path/${system}"  -m "${mount}" $cache_flags ${no_bwrap}
 
 if [ ! $? -eq 0 ]; then
     # delete stackinator tool once it is no longer needed


### PR DESCRIPTION
The develop flag is no longer needed with stackinator 6.

Stackinator 5 was patched to assume "develop" branch is being used if it can't automatically determine the version.