### PR TITLE
CI: bump update python (and streamline venv setup)

### DIFF
--- a/stage-test
+++ b/stage-test
@@ -110,18 +110,15 @@ squashfs_path="${artifact_path}/store.squashfs"
 log "set up a python venv and pip install reframe"
 [[ -z "${SLURM_PARTITION}" ]] && RFM_SYSTEM="${system}" || RFM_SYSTEM="${system}:${SLURM_PARTITION}"
 
-rm -rf rfm_venv
-python3.11 -m venv rfm_venv
-source rfm_venv/bin/activate
-#pip install --upgrade reframe-hpc
-git clone --single-branch --branch v4.9.0 https://github.com/reframe-hpc/reframe.git
-(cd reframe; ./bootstrap.sh)
-export PATH="$(pwd)/reframe/bin:$PATH"
-
 log "clone cscs-reframe-tests"
 rm -rf cscs-reframe-tests
 git clone --single-branch --branch main https://github.com/eth-cscs/cscs-reframe-tests.git
-pip install python-hostlist pyfirecrest
+
+log "setup python venv with reframe"
+rm -rf rfm_venv
+python3.11 -m venv rfm_venv
+source rfm_venv/bin/activate
+pip install -r cscs-reframe-tests/requirements.txt
 
 export UENV="${squashfs_path}"
 export RFM_AUTODETECT_METHODS="cat /etc/xthostname,hostname"

--- a/stage-test
+++ b/stage-test
@@ -116,9 +116,9 @@ git clone --single-branch --branch main https://github.com/eth-cscs/cscs-reframe
 
 log "setup python venv with reframe"
 rm -rf rfm_venv
-python3.11 -m venv rfm_venv
+uv venv rfm_venv
 source rfm_venv/bin/activate
-pip install -r cscs-reframe-tests/requirements.txt
+uv pip install -r cscs-reframe-tests/requirements.txt
 
 export UENV="${squashfs_path}"
 export RFM_AUTODETECT_METHODS="cat /etc/xthostname,hostname"

--- a/stage-test
+++ b/stage-test
@@ -117,7 +117,7 @@ log "setup python venv with reframe"
 rm -rf rfm_venv
 uv venv rfm_venv
 source rfm_venv/bin/activate
-uv pip install -r cscs-reframe-tests/requirements.txt
+uv pip install --link-mode=copy -r cscs-reframe-tests/requirements.txt
 
 export UENV="${squashfs_path}"
 export RFM_AUTODETECT_METHODS="cat /etc/xthostname,hostname"

--- a/stage-test
+++ b/stage-test
@@ -111,7 +111,7 @@ log "set up a python venv and pip install reframe"
 [[ -z "${SLURM_PARTITION}" ]] && RFM_SYSTEM="${system}" || RFM_SYSTEM="${system}:${SLURM_PARTITION}"
 
 rm -rf rfm_venv
-python3 -m venv rfm_venv
+python3.11 -m venv rfm_venv
 source rfm_venv/bin/activate
 #pip install --upgrade reframe-hpc
 git clone --single-branch --branch v4.9.0 https://github.com/reframe-hpc/reframe.git

--- a/stage-test
+++ b/stage-test
@@ -107,7 +107,6 @@ oras pull --registry-config ${jfrog_creds_path} --output "${artifact_path}" "${r
 [[ $? -eq 0  ]] || err "failed to download squashfs"
 squashfs_path="${artifact_path}/store.squashfs"
 
-log "set up a python venv and pip install reframe"
 [[ -z "${SLURM_PARTITION}" ]] && RFM_SYSTEM="${system}" || RFM_SYSTEM="${system}:${SLURM_PARTITION}"
 
 log "clone cscs-reframe-tests"


### PR DESCRIPTION
In https://github.com/eth-cscs/alps-uenv/pull/294 tests failed (similarly to https://github.com/eth-cscs/cscs-reframe-tests/pull/568#pullrequestreview-4279494904) because they are still using an old unsupported python version, specifically 3.6.

This PR aims at bumping python version to a supported one which is available on the system (unfortunately, it is hard-coded, so it would require maintenance on our side).

Moreover, I took the chance for trying to streamline the python venv setup by delegating requirements to the `cscs-reframe-tests` reposistory.