### PR TITLE
CI: UENV has been renamed to CSCS_RFM_UENV

### DIFF
--- a/stage-test
+++ b/stage-test
@@ -119,7 +119,7 @@ uv venv rfm_venv
 source rfm_venv/bin/activate
 uv pip install --link-mode=copy -r cscs-reframe-tests/requirements.txt
 
-export UENV="${squashfs_path}"
+export CSCS_RFM_UENV="${squashfs_path}"
 export RFM_AUTODETECT_METHODS="cat /etc/xthostname,hostname"
 export RFM_USE_LOGIN_SHELL=1
 


### PR DESCRIPTION
With https://github.com/eth-cscs/cscs-reframe-tests/pull/606 changes, `alps-uenv` CI stopped testing with reframe without any warning.

Indeed, no uenv was getting loaded due to variable rename, ending up in a "succesfull 0 test" reframe run.

This PR fixes that.